### PR TITLE
Melhorias gerais sobre times

### DIFF
--- a/js/presets.js
+++ b/js/presets.js
@@ -39,3 +39,25 @@ document.addEventListener('DOMContentLoaded', function () {
     const insertRulesTextArea = document.getElementById('rules-input');
     insertRulesTextArea.value = rules.join('\n');
 });
+
+document.getElementById('team-count-select').addEventListener('change', function() {
+    let selectedValue = this.value;
+    let rules;
+    
+    if (selectedValue == 2) {
+        rules = [
+            'Marcus, Lúdico',
+            'Paulo, Felipe',
+            'Anderson, Paulinho'
+        ]
+    } else {
+        rules = [
+            'Marcus, Smangol, Lúdico',
+            'Paulo, Rodolfo, Felipe',
+            'Anderson, Paulinho, Léo'
+        ]
+    }
+    
+    const insertRulesTextArea = document.getElementById('rules-input');
+    insertRulesTextArea.value = rules.join('\n');
+});

--- a/js/presets.js
+++ b/js/presets.js
@@ -1,32 +1,42 @@
-document.addEventListener('DOMContentLoaded', function () {
-    const teamCount = 3;
-    const names = [
-        'Smangol',
-        'Stéfano',
-        'Lucas',
-        'Horse',
-        'Rodolfo',
-        'Paulo',
-        'Felipe',
-        'Bazza',
-        'Marcos',
-        'Léo',
-        'Marcus',
-        'Rafael',
-        'Matheus',
-        'Anderson',
-        'Paulinho'
-    ];
+const teamCount = 3;
+const players = [
+    'Smangol',
+    'Stéfano',
+    'Lucas',
+    'Horse',
+    'Rodolfo',
+    'Paulo',
+    'Felipe',
+    'Bazza',
+    'Marcos',
+    'Léo',
+    'Marcus',
+    'Rafael',
+    'Matheus',
+    'Anderson',
+    'Paulinho'
+];
 
-    const rules = [
+const rulesByTeamCount = {
+    "2": [
+        'Marcus, Lúdico',
+        'Paulo, Felipe',
+        'Anderson, Paulinho'
+    ],
+    "3": [
         'Marcus, Smangol, Lúdico',
         'Paulo, Rodolfo, Felipe',
         'Anderson, Paulinho, Léo'
     ]
+};
 
+function updateRules () {
+    document.getElementById('rules-input').value = rulesByTeamCount[this.value].join('\n');
+}
+
+document.addEventListener('DOMContentLoaded', function () {
     const teamCountSelect = document.getElementById('team-count-select');
     for (let i = 0; i < teamCountSelect.options.length; i++) {
-        console.log(teamCountSelect.options[i].value);
         if (teamCountSelect.options[i].value === teamCount.toString()) {
             teamCountSelect.selectedIndex = i;
             break;
@@ -34,30 +44,8 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     const insertNamesTextArea = document.getElementById('names-input');
-    insertNamesTextArea.value = names.join('\n');
-
-    const insertRulesTextArea = document.getElementById('rules-input');
-    insertRulesTextArea.value = rules.join('\n');
+    insertNamesTextArea.value = players.join('\n');
+    updateRules.apply(teamCountSelect);
 });
 
-document.getElementById('team-count-select').addEventListener('change', function() {
-    let selectedValue = this.value;
-    let rules;
-    
-    if (selectedValue == 2) {
-        rules = [
-            'Marcus, Lúdico',
-            'Paulo, Felipe',
-            'Anderson, Paulinho'
-        ]
-    } else {
-        rules = [
-            'Marcus, Smangol, Lúdico',
-            'Paulo, Rodolfo, Felipe',
-            'Anderson, Paulinho, Léo'
-        ]
-    }
-    
-    const insertRulesTextArea = document.getElementById('rules-input');
-    insertRulesTextArea.value = rules.join('\n');
-});
+document.getElementById('team-count-select').addEventListener('change', updateRules);

--- a/js/team-generator.js
+++ b/js/team-generator.js
@@ -56,20 +56,21 @@ function removeUndefinedPlayers(teams) {
     return newTeams;
 }
 
-function notAllTeamsAreFull(teams, minTeamPlayers) {
-    return removeUndefinedPlayers(teams).find(team => team.length < minTeamPlayers) != null;
+function notAllTeamsAreFull(teams, totalPlayers) {
+    const minTeamPlayers = Math.floor(totalPlayers / teams.length)
+    const teamsWithoutUndefinedPlayers = removeUndefinedPlayers(teams);
+    return teamsWithoutUndefinedPlayers.find(team => team.length < minTeamPlayers) != null &&
+        teamsWithoutUndefinedPlayers.reduce((acc, team) => acc += team.length, 0);
 }
 
 function generateTeams(players, rules, teamCount) {
-    const minTeamPlayers = Math.floor(players.length / teamCount);
-
     let selectedTeams = selectTeams(players, rules, teamCount)
-    for (let attempt = 0; attempt < 100 && notAllTeamsAreFull(selectedTeams, minTeamPlayers); attempt++) {
+    for (let attempt = 0; attempt < 100 && notAllTeamsAreFull(selectedTeams, players.length); attempt++) {
         selectedTeams = selectTeams(players, rules, teamCount);
     }
 
 
-    if (notAllTeamsAreFull(selectedTeams, minTeamPlayers)) {
+    if (notAllTeamsAreFull(selectedTeams, players.length)) {
         throw new Error("Cannot generate teams")
     }
 

--- a/js/ui-script.js
+++ b/js/ui-script.js
@@ -1,5 +1,5 @@
 function generateTeamsButtonAction() {
-    setCleanPlayers();
+    sanitizePlayersTextArea()
     const namesInput = document.getElementById('names-input').value;
     const rulesInput = document.getElementById('rules-input').value;
     const teamCount = parseInt(document.getElementById('team-count-select').value, 10);
@@ -18,24 +18,14 @@ function generateTeamsButtonAction() {
         displayOnlyTeamResults(teamCount);
     } catch (e) {
         displayOnlyErrorMessage();
-        console.log(e);
+        console.error(e);
     }
     window.scrollTo(0, 0);
 }
 
-// Deprecated
-function sanitizePlayers(playersString) {
-    const pattern = "(?:\\d{1,2}\\s*-\\s*(?:(?:((?:[A-zÀ-ú]+\\s*[0-9]?\\s*)+))❌\\s*)?(?:(?:((?:[A-zÀ-ú]+\\s*[0-9]?\\s*)+))✅?))|(?:(?:((?:[A-zÀ-ú]+\\s*[0-9]?\\s*)+)))";
-
-    return playersString.split('\n')
-        .map(p => p.trim())
-        .map(p => p.replaceAll("✖️", "❌").replaceAll("✔️", "✅").replaceAll("☑️", "✅"))
-        .filter(p =>
-            new RegExp(pattern, "g").test(p)
-        )
-        .map(p => new RegExp(pattern, "g").exec(p).filter(Boolean).pop())
-        .filter(Boolean)
-        .map(p => p.trim());
+function sanitizePlayersTextArea() {
+    const dirtyPlayersText = document.getElementById('names-input').value;
+    document.getElementById('names-input').value = sanitizeNamesInput(dirtyPlayersText);
 }
 
 function hideWelcomeMessages() {
@@ -63,9 +53,9 @@ function displayOnlyTeamResults(teamCount) {
 }
 
 function copyToClipboard() {
-    const conteudoParaCopiar = document.getElementById('copy-content').textContent;
+    const contentToCopy = document.getElementById('copy-content').textContent;
 
-    navigator.clipboard.writeText(conteudoParaCopiar)
+    navigator.clipboard.writeText(contentToCopy)
         .then(() => {
             document.getElementById('copy-feedback-message').style.display = 'block';
         })
@@ -76,30 +66,26 @@ function copyToClipboard() {
         });
 }
 
-function setCleanPlayers() {
-    let namesInput = document.getElementById('names-input').value;
-    let namesInputTextArea = document.getElementById('names-input');
-    let jogadoresCorrigido;
+function sanitizeNamesInput(namesInput) {
+    return namesInput.replace(/^.*mensalista não confirmado:/s, '')
+        .replaceAll("✖️", "❌")
+        .replaceAll("✔️", "✅")
+        .replaceAll("☑️", "✅")
+        .split('\n')
+        .map(line => line.trim())
+        .filter(line => Boolean(line) && !line.includes('🧤'))
+        .map(line => {
+            let player = '';
+            let transformedLine = line.replace(/^\d+\s*-\s*/, '');
+            const alreadySanitized = line.match(/^(?:[A-zÀ-ú]+\s*[0-9]?\s*)+$/);
+            if (transformedLine.includes('❌')) { // Considerar avulsos
+                player = line.split('❌')[1].trim();
+            } else if (alreadySanitized || transformedLine.includes('✅')) { // Somente considerar mensalista confirmado
+                player = transformedLine;
+            }
 
-    const regexHeader = /^.*mensalista não confirmado:/s;
-    jogadoresCorrigido = namesInput.replace(regexHeader, '');
-    
-    let linhas = jogadoresCorrigido.split('\n');
-    let linhasFiltradas = linhas.filter(linha => linha.trim() !== '' && !linha.includes('🧤'));
-    let linhasProcessadas = linhasFiltradas.map(linha => {
-        linha = linha.replace(/^\d+\s*-\s*/, '');
-
-        // Considerar avulsos
-        if (linha.includes('❌')) {
-            let partes = linha.split('❌');
-            linha = partes[1].trim();
-        }
-
-        linha = linha.replace(/✅/g, '').trim();
-
-        return linha;
-    });
-
-    jogadoresCorrigido = linhasProcessadas.join('\n');
-    namesInputTextArea.value = jogadoresCorrigido;
+            return player.replace(/✅/g, '').trim();
+        })
+        .filter(Boolean)
+        .join('\n');
 }

--- a/js/ui-script.js
+++ b/js/ui-script.js
@@ -1,8 +1,9 @@
 function generateTeamsButtonAction() {
+    setCleanPlayers();
     const namesInput = document.getElementById('names-input').value;
     const rulesInput = document.getElementById('rules-input').value;
     const teamCount = parseInt(document.getElementById('team-count-select').value, 10);
-    const players = sanitizePlayers(namesInput);
+    const players = namesInput.split('\n').map(name => name.trim());
     const rules = rulesInput.split('\n').map(rule => rule.split(",").map(player => player.trim()));
 
     try {
@@ -17,10 +18,12 @@ function generateTeamsButtonAction() {
         displayOnlyTeamResults(teamCount);
     } catch (e) {
         displayOnlyErrorMessage();
+        console.log(e);
     }
     window.scrollTo(0, 0);
 }
 
+// Deprecated
 function sanitizePlayers(playersString) {
     const pattern = "(?:\\d{1,2}\\s*-\\s*(?:(?:((?:[A-zÀ-ú]+\\s*[0-9]?\\s*)+))❌\\s*)?(?:(?:((?:[A-zÀ-ú]+\\s*[0-9]?\\s*)+))✅?))|(?:(?:((?:[A-zÀ-ú]+\\s*[0-9]?\\s*)+)))";
 
@@ -71,4 +74,32 @@ function copyToClipboard() {
             document.getElementById('copy-feedback-message').textContent = "Erro ao copiar os times.";
             console.error('Erro ao copiar para o clipboard: ', err);
         });
+}
+
+function setCleanPlayers() {
+    let namesInput = document.getElementById('names-input').value;
+    let namesInputTextArea = document.getElementById('names-input');
+    let jogadoresCorrigido;
+
+    const regexHeader = /^.*mensalista não confirmado:/s;
+    jogadoresCorrigido = namesInput.replace(regexHeader, '');
+    
+    let linhas = jogadoresCorrigido.split('\n');
+    let linhasFiltradas = linhas.filter(linha => linha.trim() !== '' && !linha.includes('🧤'));
+    let linhasProcessadas = linhasFiltradas.map(linha => {
+        linha = linha.replace(/^\d+\s*-\s*/, '');
+
+        // Considerar avulsos
+        if (linha.includes('❌')) {
+            let partes = linha.split('❌');
+            linha = partes[1].trim();
+        }
+
+        linha = linha.replace(/✅/g, '').trim();
+
+        return linha;
+    });
+
+    jogadoresCorrigido = linhasProcessadas.join('\n');
+    namesInputTextArea.value = jogadoresCorrigido;
 }


### PR DESCRIPTION
A necessidade veio, então vim com a solução.

1. Achei melhor em vez da função sanitizePlayers(), alterar diretamente o `value` do textarea, assim fica muito mais fácil de editar depois baseado nas necessidades. isso tambem ajuda pra na hora que for fazer pelo celular e tiver que mudar algo
2. Essa mudança também tira aquele cabeçalho, independente do dia
3. Essa mudança também tira a lista de mensais confirmados, quando é toda quinta feira do mês
4. Com dois times as regras não podem ter 3 jogadores na exclusão, então agora as regras mudam conforme o número de times. fique a vontade pra editar o commit e colocar outras regras que achar necessário. mas isso ajuda muito porque se eu nem pensei na hora, se alguém for lá tirar o time duvido que vá pensar e vai achar que o código ta quebrado (e vão te culpar)
https://github.com/user-attachments/assets/4168d8b4-0acb-4271-8e13-5fbbb07c4a4e

